### PR TITLE
#578: Adding shadow to leftSidebar header and shadow to footer. 

### DIFF
--- a/frontend/components/sidebar/left/SidebarLeft.vue
+++ b/frontend/components/sidebar/left/SidebarLeft.vue
@@ -14,7 +14,7 @@
       'w-16': sidebar.collapsed && sidebar.collapsedSwitch == true,
     }"
   >
-    <SidebarLeftHeader @toggle-pressed="setContentScrollable()" />
+    <SidebarLeftHeader :hasTop="topShadow" @toggle-pressed="setContentScrollable()" />
     <div
       ref="content"
       class="h-full overflow-x-hidden"
@@ -43,7 +43,7 @@
         :filters="getFiltersByPageType"
       />
     </div>
-    <SidebarLeftFooter />
+    <SidebarLeftFooter :hasBottom="bottomShadow"/>
   </aside>
 </template>
 
@@ -294,10 +294,28 @@ const getFiltersByPageType = computed(() => {
 
 const content = ref();
 const contentScrollable = ref(false);
+const topShadow = ref(false);
+const bottomShadow = ref(false);
 
 function setContentScrollable(): void {
   contentScrollable.value =
     content.value.scrollHeight > content.value.clientHeight ? true : false;
+  isTop();
+  isBottom();
+}
+
+function isTop(): void {
+  if (contentScrollable) {
+    topShadow.value = 
+      !(content.value.scrollTop === 0);
+  }
+}
+
+function isBottom(): void {
+  if (contentScrollable) {
+    bottomShadow.value = 
+      !(content.value.scrollHeight - content.value.clientHeight === content.value.scrollTop) && !(sidebar.collapsed && sidebar.collapsedSwitch);
+  }
 }
 
 onMounted(() => {

--- a/frontend/components/sidebar/left/SidebarLeftFooter.vue
+++ b/frontend/components/sidebar/left/SidebarLeftFooter.vue
@@ -1,6 +1,9 @@
 <template>
   <footer
     class="w-full p-1 transition-all duration-500 bg-light-distinct dark:bg-dark-distinct"
+    :class="{
+      'shadow-[rgba(0,0,15,0.5)_-10px_5px_10px_10px]': hasBottom,
+    }"
   >
     <div
       class="flex flex-col justify-center w-full p-1 space-y-1 rounded-md bg-light-header dark:bg-dark-header elem-shadow-sm"
@@ -84,6 +87,8 @@ type DisclosureButtonType = {
 const disclosureButtons = ref<DisclosureButtonType[]>([]);
 
 const disclosurePanels = ref<(Element | ComponentPublicInstance | null)[]>([]);
+
+const { hasBottom } = defineProps(["hasBottom"]);
 
 const closeOtherMenus = (id: number) => {
   disclosureButtons.value

--- a/frontend/components/sidebar/left/SidebarLeftHeader.vue
+++ b/frontend/components/sidebar/left/SidebarLeftHeader.vue
@@ -1,6 +1,9 @@
 <template>
   <header
     class="w-full pl-1 transition-all duration-500 bg-light-distinct dark:bg-dark-distinct"
+    :class="{
+      'drop-shadow-2xl': hasTop,
+    }"
   >
     <div class="flex items-center pt-3 pb-2 pl-[0.85rem] pr-6">
       <div
@@ -61,8 +64,10 @@
 </template>
 
 <script setup lang="ts">
+
 const sidebar = useSidebar();
 const emit = defineEmits(["toggle-pressed"]);
+const { hasTop } = defineProps(["hasTop"]);
 </script>
 
 <style>


### PR DESCRIPTION
Added shadow to sidebar scroll at header. I used different shadow specifications for the footer.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change works. 

-->
My pull request hopes to resolve issue #578 and possibly even #579 if the unique shadow specifications ('shadow-[rgba(0,0,15,0.5)_-10px_5px_10px_10px]') I have specified are deemed appropriate instead of ('shadow-sm shadow-zinc-700'). The functionality works as expected and the test classes depend on the value of contentScrollable, verifying there is no shadow showing when the sidebar is collapsed and only showing when content on the sidebar is opened and scrollable. 

Additionally, if the content is scrollable and left sidebar is opened, then the header shadow will only emit when the user is not at the top of the scrollbar and will only emit top shadow at the footer when the user is not at the bottom of the scrollbar. 

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #578