### PR TITLE
#644 fix persistent highlight from focus-brand custom class

### DIFF
--- a/frontend/assets/css/tailwind.css
+++ b/frontend/assets/css/tailwind.css
@@ -47,7 +47,12 @@
     @apply shadow-lg shadow-zinc-700;
   }
 
-  .focus-brand {
+  .focus-brand:not(:focus-visible) {
+    /* Remove focus indication when a mouse is used */
+    outline: none;
+  }
+
+  :focus-visible {
     @apply rounded-sm focus:ring-2 focus:ring-light-link-text dark:focus:ring-dark-link-text focus:outline-none focus:border-light-link-text dark:focus:border-dark-link-text;
   }
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Bug-fix for the persistent highlight from the focus-brand custom class. Now the blue outline is not displayed around text when a mouse is used. However, it is still displayed the moment a user switches to keyboard input, in accordance with web accessibility guidelines.

Tested this change by manually trying out different sequences of inputs on a version of the website hosted on my local machine.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #644
